### PR TITLE
fix autolinting on changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint-staged": "10.2.11"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,json}": [
+    "**/*.{js,jsx,json}": [
       "eslint --fix"
     ]
   },


### PR DESCRIPTION
copied this line in, but didn't change it to reflect our file structure. this fixes that and just lints all of the json/js files.