### PR TITLE
feature: fix login on production with redirect_uri from environment

### DIFF
--- a/lib/__tests__/config.test.js
+++ b/lib/__tests__/config.test.js
@@ -1,33 +1,32 @@
 import config from '../config'
 
+const BASE_URL = 'BASE_URL'
+
 describe('config', () => {
   it('has a client id', () => {
     expect.assertions(1)
-    expect(config).toHaveProperty(
+    expect(config(BASE_URL)).toHaveProperty(
       'AUTH0_CLIENT_ID',
       process.env.AUTH0_CLIENT_ID
     )
   })
   it('has an auth0 domain', () => {
     expect.assertions(1)
-    expect(config).toHaveProperty('AUTH0_DOMAIN', process.env.AUTH0_DOMAIN)
+    expect(config(BASE_URL)).toHaveProperty(
+      'AUTH0_DOMAIN',
+      process.env.AUTH0_DOMAIN
+    )
   })
   it('has an auth0 scope', () => {
     expect.assertions(1)
-    expect(config).toHaveProperty('AUTH0_SCOPE', process.env.AUTH0_SCOPE)
+    expect(config(BASE_URL)).toHaveProperty(
+      'AUTH0_SCOPE',
+      process.env.AUTH0_SCOPE
+    )
   })
-  it('has a post logout redirect URI', () => {
-    expect.assertions(1)
-    expect(config).toHaveProperty('POST_LOGOUT_REDIRECT_URI')
-  })
-  it('has a redirect URI', () => {
-    expect.assertions(1)
-    expect(config).toHaveProperty('REDIRECT_URI')
-  })
-
   it('has a cooke lifetime', () => {
     expect.assertions(1)
-    expect(config).toHaveProperty(
+    expect(config(BASE_URL)).toHaveProperty(
       'SESSION_COOKIE_LIFETIME',
       process.env.SESSION_COOKIE_LIFETIME
     )

--- a/lib/auth0.js
+++ b/lib/auth0.js
@@ -1,23 +1,30 @@
 import { initAuth0 } from '@auth0/nextjs-auth0'
+import absoluteUrl from 'next-absolute-url'
 import config from './config'
 
-const c = {
-  audience: config.API_AUDIENCE,
-  clientId: config.AUTH0_CLIENT_ID,
-  clientSecret: config.AUTH0_CLIENT_SECRET,
-  scope: config.AUTH0_SCOPE,
-  domain: config.AUTH0_DOMAIN,
-  redirectUri: config.REDIRECT_URI,
-  postLogoutRedirectUri: config.POST_LOGOUT_REDIRECT_URI,
-  session: {
-    // The secret used to encrypt the cookie.
-    cookieSecret: config.SESSION_COOKIE_SECRET,
-    // The cookie lifetime (expiration) in seconds.
-    cookieLifetime: config.SESSION_COOKIE_LIFETIME,
-    storeIdToken: false,
-    storeRefreshToken: false,
-    storeAccessToken: true,
-  },
+const getConfigWith = (baseUrl) => {
+  const generatedConfig = config(baseUrl)
+  return {
+    audience: generatedConfig.API_AUDIENCE,
+    clientId: generatedConfig.AUTH0_CLIENT_ID,
+    clientSecret: generatedConfig.AUTH0_CLIENT_SECRET,
+    scope: generatedConfig.AUTH0_SCOPE,
+    domain: generatedConfig.AUTH0_DOMAIN,
+    redirectUri: generatedConfig.REDIRECT_URI,
+    postLogoutRedirectUri: generatedConfig.POST_LOGOUT_REDIRECT_URI,
+    session: {
+      // The secret used to encrypt the cookie.
+      cookieSecret: generatedConfig.SESSION_COOKIE_SECRET,
+      // The cookie lifetime (expiration) in seconds.
+      cookieLifetime: generatedConfig.SESSION_COOKIE_LIFETIME,
+      storeIdToken: false,
+      storeRefreshToken: false,
+      storeAccessToken: true,
+    },
+  }
 }
 
-export default initAuth0(c)
+export default (request) => {
+  const requestUrl = absoluteUrl(request).origin
+  return initAuth0(getConfigWith(requestUrl))
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,32 +1,37 @@
-const baseUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : 'http://localhost:3000'
+// const baseUrl = process.env.VERCEL_URL
+//   ? `https://${process.env.VERCEL_URL}`
+//   : 'http://localhost:3000'
 
 if (typeof window === 'undefined') {
   /**
    * Settings exposed to the server.
    */
-  module.exports = {
-    AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
-    AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
-    AUTH0_SCOPE: process.env.AUTH0_SCOPE,
-    AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
-    API_AUDIENCE: process.env.API_AUDIENCE,
-    API_BASE_URL: process.env.API_BASE_URL,
-    REDIRECT_URI: `${baseUrl}/api/callback`,
-    POST_LOGOUT_REDIRECT_URI: `${baseUrl}/`,
-    SESSION_COOKIE_SECRET: process.env.SESSION_COOKIE_SECRET,
-    SESSION_COOKIE_LIFETIME: process.env.SESSION_COOKIE_LIFETIME,
+  module.exports = (baseUrl) => {
+    return {
+      AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+      AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
+      AUTH0_SCOPE: process.env.AUTH0_SCOPE,
+      AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+      API_AUDIENCE: process.env.API_AUDIENCE,
+      REDIRECT_URI: process.env.REDIRECT_URI || `${baseUrl}/api/callback`,
+      POST_LOGOUT_REDIRECT_URI:
+        process.env.POST_LOGOUT_REDIRECT_URI || `${baseUrl}/`,
+      SESSION_COOKIE_SECRET: process.env.SESSION_COOKIE_SECRET,
+      SESSION_COOKIE_LIFETIME: process.env.SESSION_COOKIE_LIFETIME,
+    }
   }
 } else {
   /**
    * Settings exposed to the client.
    */
-  module.exports = {
-    AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
-    AUTH0_SCOPE: process.env.AUTH0_SCOPE,
-    AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
-    REDIRECT_URI: `${baseUrl}/api/callback`,
-    POST_LOGOUT_REDIRECT_URI: `${baseUrl}/`,
+  module.exports = (baseUrl) => {
+    return {
+      AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+      AUTH0_SCOPE: process.env.AUTH0_SCOPE,
+      AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+      REDIRECT_URI: process.env.REDIRECT_URI || `${baseUrl}/api/callback`,
+      POST_LOGOUT_REDIRECT_URI:
+        process.env.POST_LOGOUT_REDIRECT_URI || `${baseUrl}/`,
+    }
   }
 }

--- a/pages/api/callback.js
+++ b/pages/api/callback.js
@@ -2,7 +2,7 @@ import auth0 from '../../lib/auth0'
 
 export default async function callback(request, response) {
   try {
-    await auth0.handleCallback(request, response)
+    await auth0(request).handleCallback(request, response)
   } catch (error) {
     console.error(error)
     response.status(error.status || 500).end(error.message)

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,19 +1,8 @@
-import absoluteUrl from 'next-absolute-url'
 import auth0 from '../../lib/auth0'
 
 export default async function login(request, response) {
   try {
-    // TODO: this should happen at every URL to redirect to canonical URLs.
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000'
-    const requestUrl = absoluteUrl(request).origin
-    if (baseUrl !== requestUrl) {
-      response.writeHead(301, { Location: `${baseUrl}${request.url}` })
-      response.end()
-    } else {
-      await auth0.handleLogin(request, response)
-    }
+    await auth0(request).handleLogin(request, response)
   } catch (error) {
     console.error(error)
     response.status(error.status || 500).end(error.message)

--- a/pages/api/logout.js
+++ b/pages/api/logout.js
@@ -2,7 +2,7 @@ import auth0 from '../../lib/auth0'
 
 export default async function logout(request, response) {
   try {
-    await auth0.handleLogout(request, response)
+    await auth0(request).handleLogout(request, response)
   } catch (error) {
     console.error(error)
     response.status(error.status || 500).end(error.message)

--- a/pages/api/me.js
+++ b/pages/api/me.js
@@ -2,7 +2,7 @@ import auth0 from '../../lib/auth0'
 
 export default async function me(request, response) {
   try {
-    await auth0.handleProfile(request, response)
+    await auth0(request).handleProfile(request, response)
   } catch (error) {
     console.error(error)
     response.status(error.status || 500).end(error.message)


### PR DESCRIPTION
Changes the way auth0 config works, such that:
* If there's a REDIRECT_URI env var, use that for the oauth callback. On production, this would be the host domain `https://theunhatched.com`. On development, the .envrc file should make this `http://localhost:3000`.
* If there's no REDIRECT_URI env var, then figure out the oauth callback URL from the request.